### PR TITLE
Fix nil pointer in NewEnvChrome case

### DIFF
--- a/bindings/muniverse-bind/main.go
+++ b/bindings/muniverse-bind/main.go
@@ -135,7 +135,7 @@ func (b *Server) newEnv(call *Call) *Response {
 			CustomImage: call.NewEnvContainer.Container,
 		}
 	case call.NewEnvChrome != nil:
-		spec = call.NewEnvContainer.Spec
+		spec = call.NewEnvChrome.Spec
 		opts = &muniverse.Options{
 			DevtoolsHost: call.NewEnvChrome.Host,
 			GameHost:     call.NewEnvChrome.GameHost,


### PR DESCRIPTION
Debugging through a binding is confusing:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x6778d9]

goroutine 6 [running]:
main.(*Server).newEnv(0xc42005a320, 0xc42001e480, 0x0)
        github.com/unixpickle/muniverse/bindings/muniverse-bind/main.go:138 +0x3c9
...